### PR TITLE
Add pyzmq

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ Find some of those *awesome* packages here and if you are missing one we count o
 *Libraries to implement applications using message queues.*
 
 * [aioamqp](https://github.com/Polyconseil/aioamqp) - AMQP implementation using asyncio.
-* [aiozmq](https://github.com/aio-libs/aiozmq) - Asyncio (pep 3156) integration with ZeroMQ.
+* [pyzmq](https://github.com/zeromq/pyzmq) - Python bindings for ZeroMQ.
+* [aiozmq](https://github.com/aio-libs/aiozmq) - Alternative Asyncio integration with ZeroMQ.
 * [crossbar](https://github.com/crossbario/crossbar) - Crossbar.io is a networking platform for distributed and microservice applications.
 * [asyncio-nats](https://github.com/nats-io/asyncio-nats) - Client for the NATS messaging system.
 * [aiokafka](https://github.com/aio-libs/aiokafka) - Client for Apache Kafka.


### PR DESCRIPTION
The [pyzmq](https://github.com/zeromq/pyzmq) library already [supports asyncio](https://github.com/zeromq/pyzmq/blob/master/examples/asyncio/coroutines.py). But for long time a custom I/O loop must have been used.
With pyzmq version 17 (released on 10 Feb 2018) pyzmq [works with the default I/O loop](https://github.com/zeromq/pyzmq/commit/f2457b349ce462fcef226e5637b7c862ee1fac95) and the aiozmq arguments (about aiohttp incompatibility etc.) are no longer valid.
